### PR TITLE
Remove explicit casting to Boolean

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ function toVal(mix) {
 	var k, y, str='';
 	if (mix) {
 		if (typeof mix === 'object') {
-			if (!!mix.push) {
+			if (mix.push) {
 				for (k=0; k < mix.length; k++) {
 					if (mix[k] && (y = toVal(mix[k]))) {
 						str && (str += ' ');


### PR DESCRIPTION
There is no need to explicitly cast the expression inside `if` statement to boolean, so we can remove `!!`.

Please let me know if it was done by intention @lukeed 

Locally benchmarks show weird results even if I don't change anything