### PR TITLE
fix(types): Avoid `any`

### DIFF
--- a/clsx.d.ts
+++ b/clsx.d.ts
@@ -1,7 +1,7 @@
 export type ClassValue = ClassArray | ClassDictionary | string | number | null | boolean | undefined;
 
 export interface ClassDictionary {
-	[id: string]: any;
+	[id: string]: string | number | null | boolean | undefined;
 }
 
 export interface ClassArray extends Array<ClassValue> { }


### PR DESCRIPTION
The current types trigger the [@typescript-eslint/no-unsafe-assignment rule](https://github.com/typescript-eslint/typescript-eslint/blob/v3.4.0/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md).

I believe this change covers all cases.