### PR TITLE
increase perf && smaller size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function toVal(mix) {
 		} else {
 			for (k in mix) {
 				if (mix[k]) {
-					str && (str += " ");
+					str && (str += ' ');
 					str += k;
 				}
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -7,18 +7,18 @@ function toVal(mix) {
 	
 	if (typeof mix === 'object') {
 		if (Array.isArray(mix)) {
-			for (k=0; k < mix.length; k++) {
-				if (mix[k]) {
-					if (y = toVal(mix[k])) {
+			for (y=0; y < mix.length; y++) {
+				if (mix[y]) {
+					if (k = toVal(mix[y])) {
 						str && (str += ' ');
-						str += y;
+						str += k;
 					}
 				}
 			}
 		} else {
 			for (k in mix) {
 				if (mix[k]) {
-					str && (str += ' ');
+					str && (str += " ");
 					str += k;
 				}
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,10 @@ function toVal(mix) {
 	var k, y, str='';
 
 	if (typeof mix === 'string' || typeof mix === 'number') {
-		str += mix;
-	} else if (typeof mix === 'object') {
+		return mix;
+	}
+	
+	if (typeof mix === 'object') {
 		if (Array.isArray(mix)) {
 			for (k=0; k < mix.length; k++) {
 				if (mix[k]) {

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,11 @@ test('strings', t => {
 	t.end();
 });
 
+test('numbers', t => {
+	t.equal(fn(123, 456), '123 456');
+	t.end();
+});
+
 test('strings (variadic)', t => {
 	t.is(fn(''), '');
 	t.is(fn('foo'), 'foo');


### PR DESCRIPTION
Size before:
```
Filename                Filesize  (gzip)
dist\clsx.js              358 B   230 B
dist\clsx.m.js            357 B   228 B
dist\clsx.min.js          517 B   290 B
```
Size after:
```
Filename                Filesize  (gzip)
dist\clsx.js              357 B   226 B
dist\clsx.m.js            356 B   224 B
dist\clsx.min.js          516 B   286 B
```

Perf on my Dell xps 13 9360 Core-i78550U:
```
# Strings
  classcat*    x 6,205,951 ops/sec ±1.11% (88 runs sampled)
  classnames   x 3,171,871 ops/sec ±0.81% (87 runs sampled)
  clsx (prev)  x 7,099,800 ops/sec ±1.39% (88 runs sampled)
  clsx         x 7,602,434 ops/sec ±1.93% (82 runs sampled)

# Objects
  classcat*    x 5,344,027 ops/sec ±1.82% (86 runs sampled)
  classnames   x 2,986,700 ops/sec ±0.80% (92 runs sampled)
  clsx (prev)  x 4,597,446 ops/sec ±1.39% (86 runs sampled)
  clsx         x 6,105,959 ops/sec ±1.16% (91 runs sampled)

# Arrays
  classcat*    x 4,923,076 ops/sec ±2.19% (85 runs sampled)
  classnames   x 1,643,135 ops/sec ±0.86% (90 runs sampled)
  clsx (prev)  x 5,329,721 ops/sec ±1.08% (87 runs sampled)
  clsx         x 5,498,393 ops/sec ±1.56% (88 runs sampled)

# Nested Arrays
  classcat*    x 3,995,324 ops/sec ±1.78% (83 runs sampled)
  classnames   x 1,010,578 ops/sec ±0.74% (93 runs sampled)
  clsx (prev)  x 3,977,924 ops/sec ±1.73% (86 runs sampled)
  clsx         x 4,258,622 ops/sec ±1.76% (86 runs sampled)

# Nested Arrays w/ Objects
  classcat*    x 4,425,302 ops/sec ±1.25% (88 runs sampled)
  classnames   x 1,578,490 ops/sec ±0.89% (90 runs sampled)
  clsx (prev)  x 3,967,503 ops/sec ±1.34% (85 runs sampled)
  clsx         x 4,465,872 ops/sec ±2.08% (86 runs sampled)

# Mixed
  classcat*    x 4,336,818 ops/sec ±2.65% (85 runs sampled)
  classnames   x 2,016,569 ops/sec ±0.94% (91 runs sampled)
  clsx (prev)  x 4,304,082 ops/sec ±1.77% (86 runs sampled)
  clsx         x 4,876,592 ops/sec ±1.97% (86 runs sampled)

# Mixed (Bad Data)
  classcat*    x 1,092,890 ops/sec ±3.88% (78 runs sampled)
  classnames   x 946,727 ops/sec ±1.09% (91 runs sampled)
  clsx (prev)  x 1,400,982 ops/sec ±2.10% (84 runs sampled)
  clsx         x 1,613,103 ops/sec ±1.57% (86 runs sampled)
```