### PR TITLE
perf: reuse typeof result

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 function toVal(mix) {
-	var k, y, str='';
+	var k, y = typeof mix, str = '';
 
-	if (typeof mix === 'string' || typeof mix === 'number') {
+	if (y === 'string' || y === 'number') {
 		str += mix;
-	} else if (typeof mix === 'object') {
+	} else if (y === 'object') {
 		if (Array.isArray(mix)) {
 			for (k=0; k < mix.length; k++) {
 				if (mix[k]) {


### PR DESCRIPTION
Hi, I think this small change improves the performance slightly ;)

```
# Strings
  classcat*    x 6,665,229 ops/sec ±0.73% (91 runs sampled)
  classnames   x 3,445,132 ops/sec ±1.66% (93 runs sampled)
  clsx (prev)  x 8,113,020 ops/sec ±0.47% (90 runs sampled)
  clsx         x 8,151,343 ops/sec ±0.56% (94 runs sampled)

# Objects
  classcat*    x 6,207,132 ops/sec ±0.37% (95 runs sampled)
  classnames   x 3,261,962 ops/sec ±0.37% (95 runs sampled)
  clsx (prev)  x 4,634,499 ops/sec ±0.70% (93 runs sampled)
  clsx         x 6,344,570 ops/sec ±0.42% (94 runs sampled)

# Arrays
  classcat*    x 5,923,376 ops/sec ±0.46% (95 runs sampled)
  classnames   x 1,529,935 ops/sec ±1.57% (94 runs sampled)
  clsx (prev)  x 5,547,482 ops/sec ±0.40% (92 runs sampled)
  clsx         x 5,789,342 ops/sec ±0.69% (93 runs sampled)

# Nested Arrays
  classcat*    x 4,529,590 ops/sec ±0.52% (93 runs sampled)
  classnames   x 1,042,453 ops/sec ±1.32% (94 runs sampled)
  clsx (prev)  x 4,094,879 ops/sec ±0.38% (93 runs sampled)
  clsx         x 4,611,227 ops/sec ±0.43% (92 runs sampled)

# Nested Arrays w/ Objects
  classcat*    x 5,037,552 ops/sec ±0.47% (94 runs sampled)
  classnames   x 1,465,800 ops/sec ±0.72% (93 runs sampled)
  clsx (prev)  x 4,126,853 ops/sec ±0.58% (95 runs sampled)
  clsx         x 5,056,852 ops/sec ±0.54% (94 runs sampled)

# Mixed
  classcat*    x 5,064,610 ops/sec ±0.86% (91 runs sampled)
  classnames   x 2,018,246 ops/sec ±1.90% (90 runs sampled)
  clsx (prev)  x 4,653,088 ops/sec ±0.87% (93 runs sampled)
  clsx         x 5,360,304 ops/sec ±0.43% (92 runs sampled)

# Mixed (Bad Data)
  classcat*    x 1,447,406 ops/sec ±0.37% (95 runs sampled)
  classnames   x 958,893 ops/sec ±0.32% (93 runs sampled)
  clsx (prev)  x 1,657,026 ops/sec ±0.42% (92 runs sampled)
  clsx         x 1,883,869 ops/sec ±0.35% (94 runs sampled)
```