### PR TITLE
feat: enhance performance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,8 @@ function toVal(mix) {
 		str += mix;
 	} else if (typeof mix === 'object') {
 		if (Array.isArray(mix)) {
-			var len=mix.length, k=0;
-			for (; k < len; k++) {
+			var len=mix.length;
+			for (k = 0; k < len; k++) {
 				if (mix[k]) {
 					if (y = toVal(mix[k])) {
 						str && (str += ' ');

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ function toVal(mix) {
 		str += mix;
 	} else if (typeof mix === 'object') {
 		if (Array.isArray(mix)) {
-			for (k=0; k < mix.length; k++) {
+			var len=mix.length, k=0;
+			for (; k < len; k++) {
 				if (mix[k]) {
 					if (y = toVal(mix[k])) {
 						str && (str += ' ');
@@ -27,9 +28,9 @@ function toVal(mix) {
 }
 
 export default function () {
-	var i=0, tmp, x, str='';
-	while (i < arguments.length) {
-		if (tmp = arguments[i++]) {
+	var i=0, tmp, x, str='', len=arguments.length;
+	for (; i < len; i++) {
+		if (tmp = arguments[i]) {
 			if (x = toVal(tmp)) {
 				str && (str += ' ');
 				str += x

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ function toVal(mix) {
 	} else if (typeof mix === 'object') {
 		if (Array.isArray(mix)) {
 			var len=mix.length;
-			for (k = 0; k < len; k++) {
+			for (k=0; k < len; k++) {
 				if (mix[k]) {
 					if (y = toVal(mix[k])) {
 						str && (str += ' ');
@@ -27,7 +27,7 @@ function toVal(mix) {
 	return str;
 }
 
-export default function () {
+export function clsx() {
 	var i=0, tmp, x, str='', len=arguments.length;
 	for (; i < len; i++) {
 		if (tmp = arguments[i]) {


### PR DESCRIPTION
Hi friends, I did some minor changes to increase performance. the benchmark result is:

```
# Strings
  classcat*    x 6,206,358 ops/sec ±1.24% (90 runs sampled)
  classnames   x 3,408,198 ops/sec ±0.88% (92 runs sampled)
  clsx (prev)  x 7,434,060 ops/sec ±0.92% (93 runs sampled)
  clsx         x 8,112,152 ops/sec ±0.90% (92 runs sampled)

# Objects
  classcat*    x 5,865,653 ops/sec ±0.89% (92 runs sampled)
  classnames   x 3,108,156 ops/sec ±0.90% (92 runs sampled)
  clsx (prev)  x 4,765,299 ops/sec ±0.83% (93 runs sampled)
  clsx         x 6,063,173 ops/sec ±0.93% (93 runs sampled)

# Arrays
  classcat*    x 5,471,773 ops/sec ±0.81% (92 runs sampled)
  classnames   x 1,811,028 ops/sec ±0.71% (94 runs sampled)
  clsx (prev)  x 5,606,905 ops/sec ±1.12% (91 runs sampled)
  clsx         x 5,710,108 ops/sec ±0.94% (92 runs sampled)

# Nested Arrays
  classcat*    x 4,333,798 ops/sec ±0.97% (90 runs sampled)
  classnames   x 1,066,391 ops/sec ±0.70% (93 runs sampled)
  clsx (prev)  x 4,351,329 ops/sec ±1.05% (93 runs sampled)
  clsx         x 4,505,775 ops/sec ±0.94% (92 runs sampled)

# Nested Arrays w/ Objects
  classcat*    x 4,524,749 ops/sec ±0.99% (92 runs sampled)
  classnames   x 1,716,114 ops/sec ±0.78% (94 runs sampled)
  clsx (prev)  x 4,239,522 ops/sec ±0.96% (91 runs sampled)
  clsx         x 4,702,464 ops/sec ±0.96% (93 runs sampled)

# Mixed
  classcat*    x 4,826,735 ops/sec ±0.89% (94 runs sampled)
  classnames   x 2,144,730 ops/sec ±0.92% (91 runs sampled)
  clsx (prev)  x 4,651,749 ops/sec ±1.04% (89 runs sampled)
  clsx         x 5,129,713 ops/sec ±0.89% (91 runs sampled)

# Mixed (Bad Data)
  classcat*    x 1,400,863 ops/sec ±0.87% (92 runs sampled)
  classnames   x 1,038,999 ops/sec ±0.81% (93 runs sampled)
  clsx (prev)  x 1,708,531 ops/sec ±0.98% (93 runs sampled)
  clsx         x 1,830,703 ops/sec ±1.03% (93 runs sampled)
```

> Perf on MacBook Pro, 2.9 GHz Quad-Core Intel Core i7, 16 GB Ram