### PR TITLE
tests: test string variadic group w/ actual variable string args

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -17,9 +17,9 @@ test('strings', t => {
 
 test('strings (variadic)', t => {
 	t.is(fn(''), '');
-	t.is(fn('foo'), 'foo');
-	t.is(fn(true && 'foo'), 'foo');
-	t.is(fn(false && 'foo'), '');
+	t.is(fn('foo', 'bar'), 'foo bar');
+	t.is(fn(true && 'foo', false && bar, 'baz'), 'foo baz');
+	t.is(fn(false && 'foo', 'bar', 'baz', ''), 'bar baz');
 	t.end();
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ test('strings', t => {
 test('strings (variadic)', t => {
 	t.is(fn(''), '');
 	t.is(fn('foo', 'bar'), 'foo bar');
-	t.is(fn(true && 'foo', false && bar, 'baz'), 'foo baz');
+	t.is(fn(true && 'foo', false && 'bar', 'baz'), 'foo baz');
 	t.is(fn(false && 'foo', 'bar', 'baz', ''), 'bar baz');
 	t.end();
 });


### PR DESCRIPTION
I noticed that the `strings (variadic)` section of the tests were actually redundant with the single argument tests. I updated them to include variable numbers of string args.