### PR TITLE
 chore(action): add newer nodejs, update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nodejs: [6, 8, 10, 12]
+        nodejs: [6, 8, 10, 12, 14, 16]
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.nodejs }}
 


### PR DESCRIPTION
## Changes:

- Updates `actions/checkout` to `@v2`, which is the latest stable version
- Updates `actions/setup-node` to `@v2`, which is the latest stable release
- Add Node 14 and 16 to the test matrix

## Context:

I noticed you're using outdated versions of the GitHub Action runners, and are not testing on newer versions of Node.

I've left out Node 15 from the test matrix, as that version is end-of-life already.
Node 14 is current long term supported version, and Node 16 will be the new long term supported version soon.

The newer actions should work just fine, but run them first on the PR to make sure. 😄 

Links to release change-logs for the updated actions:

- https://github.com/actions/checkout/releases
- https://github.com/actions/setup-node/releases