### PR TITLE
fix: fix esm support and types

### DIFF
--- a/clsx.d.mts
+++ b/clsx.d.mts
@@ -1,0 +1,6 @@
+export type ClassValue = ClassArray | ClassDictionary | string | number | null | boolean | undefined;
+export type ClassDictionary = Record<string, any>;
+export type ClassArray = ClassValue[];
+
+export function clsx(...inputs: ClassValue[]): string;
+export default clsx;

--- a/clsx.d.ts
+++ b/clsx.d.ts
@@ -1,6 +1,10 @@
-export type ClassValue = ClassArray | ClassDictionary | string | number | null | boolean | undefined;
-export type ClassDictionary = Record<string, any>;
-export type ClassArray = ClassValue[];
+declare namespace clsx {
+	type ClassValue = ClassArray | ClassDictionary | string | number | null | boolean | undefined;
+	type ClassDictionary = Record<string, any>;
+	type ClassArray = ClassValue[];
+	function clsx(...inputs: ClassValue[]): string;
+}
 
-export declare function clsx(...inputs: ClassValue[]): string;
-export default clsx;
+declare function clsx(...inputs: clsx.ClassValue[]): string;
+
+export = clsx;

--- a/package.json
+++ b/package.json
@@ -3,9 +3,19 @@
   "version": "1.2.1",
   "repository": "lukeed/clsx",
   "description": "A tiny (228B) utility for constructing className strings conditionally.",
-  "module": "dist/clsx.m.js",
+  "module": "dist/clsx.mjs",
   "unpkg": "dist/clsx.min.js",
   "main": "dist/clsx.js",
+  "exports": {
+    "import": {
+      "types": "./clsx.d.mts",
+      "default": "./dist/clsx.mjs"
+    },
+    "default": {
+      "types": "./clsx.d.ts",
+      "default": "./dist/clsx.js"
+    }
+  },
   "types": "clsx.d.ts",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
The non-standard `package.json` field `module` was used. This pointed to a faux ESM file (Uses ESM syntax, but has a `.js` file extension in a package which doesn’t specify `"type": "module"`.

ESM support was fixed by using the `.mjs` file extension for the ESM export and defining a proper `exports` field in `package.json.

The types reflected a package that has the `module.exports.default` field. This was incorrect. The CommonJS types have now been fixed to use `export =`, which is the correct way to type modules that use `module.exports` assignments.

Additional types were added for ESM support.

This fixes the following issues that have previously been closed without a solution.

Closes #27
Closes #43
Closes #50

To try this locally, try running the following in the Node.js repl from the package root:

```
$ node
Welcome to Node.js v18.12.0.
Type ".help" for more information.
> require('clsx')
<ref *1> [Function: r] { clsx: [Circular *1] }
> await import('clsx')
[Module: null prototype] {
  clsx: [Function: clsx],
  default: [Function: clsx]
}

```