### PR TITLE
fix(types): fix TypeScript types

### DIFF
--- a/clsx.d.ts
+++ b/clsx.d.ts
@@ -1,6 +1,10 @@
-export type ClassValue = ClassArray | ClassDictionary | string | number | null | boolean | undefined;
-export type ClassDictionary = Record<string, any>;
-export type ClassArray = ClassValue[];
+declare namespace clsx {
+	type ClassValue = ClassArray | ClassDictionary | string | number | null | boolean | undefined;
+	type ClassDictionary = Record<string, any>;
+	type ClassArray = ClassValue[];
+	function clsx(...inputs: ClassValue[]): string;
+}
 
-export declare function clsx(...inputs: ClassValue[]): string;
-export default clsx;
+declare function clsx(...inputs: clsx.ClassValue[]): string;
+
+export = clsx;


### PR DESCRIPTION
This only includes the TypeScript type fixes from #57.

---

CommonJS

```jsonc
tsconfig.json
{
  "compilerOptions": {
    "checkJs": true
  }
}
```

Before
```js
// ✗ TypeError
require('clsx')('')

// ✔️ Ok
require('clsx').clsx('')

// ✗ Runtime error
require('clsx').default('')
```

After
```js
// ✔️ Ok
require('clsx')('')

// ✔️ Ok
require('clsx').clsx('')

// ✔️ Runtime and type error
require('clsx').default('')
```

---

```jsonc
// tsconfig.json
{
  "compilerOptions": {
    "module": "node16"
  }
}
```

Before
```js
import clsx from 'clsx'
// ✗ TypeError
clsx('')
// ✗ TypeError
clsx.clsx('')
// ✗ Runtime error
clsx.default('')

// ✗ TypeError
import { clsx } from 'clsx'
```

After
```js
import clsx from 'clsx'
// ✔️ Ok
clsx('')
// ✔️ Ok
clsx.clsx('')
// ✔️ Runtime error and type error
clsx.default('')

// ✗ TypeError
import { clsx } from 'clsx'
```

---

```jsonc
// tsconfig.json
{
  "compilerOptions": {
    "esModuleInterop": true
  }
}
```

Before
```js
import clsx from 'clsx'
// ✔️ Ok
clsx('')
// ✗ TypeError
clsx.clsx('')
// ✔️ Type error and runtime error
clsx.default('')

// ✔️ Ok
import { clsx } from 'clsx'
```

After
```js
import clsx from 'clsx'
// ✔️ Ok
clsx('')
// ✔️ Ok
clsx.clsx('')
// ✔️ Type error and runtime error
clsx.default('')

// ✔️ Ok
import { clsx } from 'clsx'
```