### PR TITLE
Optimize clsx implementation for better performance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,39 +1,45 @@
 function toVal(mix) {
-	var k, y, str='';
-
-	if (typeof mix === 'string' || typeof mix === 'number') {
-		str += mix;
-	} else if (typeof mix === 'object') {
-		if (Array.isArray(mix)) {
-			for (k=0; k < mix.length; k++) {
-				if (mix[k]) {
-					if (y = toVal(mix[k])) {
-						str && (str += ' ');
-						str += y;
-					}
-				}
-			}
-		} else {
-			for (k in mix) {
-				if (mix[k]) {
-					str && (str += ' ');
-					str += k;
-				}
-			}
-		}
+	if (mix === null || mix === undefined) {
+		return '';
 	}
 
-	return str;
+	if (typeof mix === 'string' || typeof mix === 'number') {
+		return mix;
+	}
+
+	if (Array.isArray(mix)) {
+		let str = '';
+		for (let i = 0; i < mix.length; i++) {
+			const val = toVal(mix[i]);
+			if (val) {
+				str && (str += ' ');
+				str += val;
+			}
+		}
+		return str;
+	}
+
+	if (typeof mix === 'object') {
+		let str = '';
+		for (const key in mix) {
+			if (mix[key]) {
+				str && (str += ' ');
+				str += key;
+			}
+		}
+		return str;
+	}
+
+	return '';
 }
 
-export function clsx() {
-	var i=0, tmp, x, str='';
-	while (i < arguments.length) {
-		if (tmp = arguments[i++]) {
-			if (x = toVal(tmp)) {
-				str && (str += ' ');
-				str += x
-			}
+export function clsx(...args) {
+	let str = '';
+	for (let i = 0; i < args.length; i++) {
+		const val = toVal(args[i]);
+		if (val) {
+			str && (str += ' ');
+			str += val;
 		}
 	}
 	return str;


### PR DESCRIPTION
This PR optimizes the clsx implementation, resulting in more legible and faster code. the benchmarks show improved performance compared to the previous version.


Changes:

Updated toVal function to handle different input types more efficiently.
Refactored the clsx function to use a more concise approach.
Benchmark results:
```
# Strings
  clsx (prev)  x 12,954,191 ops/sec ±0.32% (95 runs sampled)
  clsx         x 14,163,905 ops/sec ±1.08% (101 runs sampled)

# Objects
  clsx (prev)  x 8,729,410 ops/sec ±0.15% (98 runs sampled)
  clsx         x 10,610,018 ops/sec ±0.15% (100 runs sampled)

# Arrays
  clsx (prev)  x 10,043,091 ops/sec ±1.28% (99 runs sampled)
  clsx         x 10,956,764 ops/sec ±0.20% (95 runs sampled)

# Nested Arrays
  clsx (prev)  x 8,232,897 ops/sec ±0.70% (93 runs sampled)
  clsx         x 9,248,651 ops/sec ±0.12% (93 runs sampled)

# Nested Arrays w/ Objects
  clsx (prev)  x 7,975,890 ops/sec ±0.10% (98 runs sampled)
  clsx         x 9,101,825 ops/sec ±0.12% (98 runs sampled)

# Mixed
  clsx (prev)  x 8,521,371 ops/sec ±1.77% (98 runs sampled)
  clsx         x 9,270,741 ops/sec ±0.72% (99 runs sampled)

# Mixed (Bad Data)
  clsx (prev)  x 3,406,695 ops/sec ±0.22% (98 runs sampled)
  clsx         x 3,822,356 ops/sec ±0.22% (99 runs sampled)
```
The updated implementation outperforms the previous version in all test cases.

The resulting build files are also smaller
```
❯ pnpm run build #before
> clsx@1.2.1 build /Users/jonas/Research/clsx
> node bin

~> "dist/clsx.m.js" (234 b)
~> "dist/clsx.js" (238 b)
~> "dist/clsx.min.js" (297 b)
❯ pnpm run build #after

> clsx@1.2.1 build /Users/jonas/Research/clsx
> node bin

~> "dist/clsx.m.js" (225 b)
~> "dist/clsx.js" (228 b)
~> "dist/clsx.min.js" (289 b)
```