### PR TITLE
chore: typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 This module is available in three formats:
 
-* **ES Module**: `dist/clsx.m.js`
+* **ES Module**: `dist/clsx.mjs`
 * **CommonJS**: `dist/clsx.js`
 * **UMD**: `dist/clsx.min.js`
 


### PR DESCRIPTION
Small typo: `clsx.m.js` -> `clsx.mjs`