### PR TITLE
docs: ignore commented out lines from VS Code IntelliSense

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ Here some additional (optional) steps to enable classes autocompletion using `cl
   ```json
    {
     "tailwindCSS.experimental.classRegex": [
-      ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+      ["^(?:(?!\/\/).*)clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
     ]
    }
   ```


### PR DESCRIPTION
This PR changes the regular expression for VS Code IntelliSense to ignore lines beginning with `//`