### PR TITLE
Fix the readme’s first link to benchmarks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # clsx [![CI](https://github.com/lukeed/clsx/workflows/CI/badge.svg)](https://github.com/lukeed/clsx/actions?query=workflow%3ACI) [![codecov](https://badgen.net/codecov/c/github/lukeed/clsx)](https://codecov.io/gh/lukeed/clsx)
 
-> A tiny (234B) utility for constructing `className` strings conditionally.<Br>Also serves as a [faster](/bench) & smaller drop-in replacement for the `classnames` module.
+> A tiny (234B) utility for constructing `className` strings conditionally.<Br>Also serves as a [faster](bench) & smaller drop-in replacement for the `classnames` module.
 
 This module is available in three formats:
 
@@ -68,7 +68,7 @@ clsx(true, false, '', null, undefined, 0, NaN);
 
 ## Benchmarks
 
-For snapshots of cross-browser results, check out the [`bench`](/bench) directory~!
+For snapshots of cross-browser results, check out the [`bench`](bench) directory~!
 
 ## Support
 


### PR DESCRIPTION
for some reason, the `faster` link at the top of the README in the description block gets interpreted as pointing to `github.com/bench`. making it a fully relative link (no leading slash) fixes that issue.

here’s a link to the readme file showing the bad link URL resolution on `master`: https://github.com/lukeed/clsx/blob/master/readme.md

and here’s a link to the readme file in the same GitHub view but from this branch: https://github.com/acusti/clsx/blob/patch-1/readme.md

oh yes, and thank you so much for this package! it’s such a wonderful asset for the community.