### PR TITLE
Proposed ability to add sub & pseudo classes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,17 @@
-function toVal(mix, key = "") {
+function toVal(mix, key = '') {
 	var k,
 		y,
-		str = "";
+		str = '';
 
-	if (typeof mix === "string" || typeof mix === "number") {
-		str += key.length ? key + ":" + mix : mix;
-	} else if (typeof mix === "object") {
+	if (typeof mix === 'string' || typeof mix === 'number') {
+		str += key.length ? key + ':' + mix : mix;
+	} else if (typeof mix === 'object') {
 		if (Array.isArray(mix)) {
 			var len = mix.length;
 			for (k = 0; k < len; k++) {
 				if (mix[k]) {
 					if ((y = toVal(mix[k], key))) {
-						str && (str += " ");
+						str && (str += ' ');
 						str += y;
 					}
 				}
@@ -19,10 +19,10 @@ function toVal(mix, key = "") {
 		} else {
 			for (y in mix) {
 				if (mix[y]) {
-					if (typeof mix[y] === "object" && typeof mix[y] !== "function") {
-						str += toVal(mix[y], key.length ? key + ":" + y : y);
+					if (typeof mix[y] === 'object' && typeof mix[y] !== 'function') {
+						str += toVal(mix[y], key.length ? key + ':' + y : y);
 					} else {
-						str && (str += " ");
+						str && (str += ' ');
 						str += y;
 					}
 				}
@@ -37,12 +37,12 @@ export function clsx() {
 	var i = 0,
 		tmp,
 		x,
-		str = "",
+		str = '',
 		len = arguments.length;
 	for (; i < len; i++) {
 		if ((tmp = arguments[i])) {
 			if ((x = toVal(tmp))) {
-				str && (str += " ");
+				str && (str += ' ');
 				str += x;
 			}
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,17 @@
-function toVal(mix) {
-	var k, y, str='';
+function toVal(mix, key = "") {
+	var k,
+		y,
+		str = "";
 
-	if (typeof mix === 'string' || typeof mix === 'number') {
-		str += mix;
-	} else if (typeof mix === 'object') {
+	if (typeof mix === "string" || typeof mix === "number") {
+		str += key.length ? key + ":" + mix : mix;
+	} else if (typeof mix === "object") {
 		if (Array.isArray(mix)) {
-			var len=mix.length;
-			for (k=0; k < len; k++) {
+			var len = mix.length;
+			for (k = 0; k < len; k++) {
 				if (mix[k]) {
-					if (y = toVal(mix[k])) {
-						str && (str += ' ');
+					if ((y = toVal(mix[k], key))) {
+						str && (str += " ");
 						str += y;
 					}
 				}
@@ -17,8 +19,12 @@ function toVal(mix) {
 		} else {
 			for (y in mix) {
 				if (mix[y]) {
-					str && (str += ' ');
-					str += y;
+					if (typeof mix[y] === "object" && typeof mix[y] !== "function") {
+						str += toVal(mix[y], key.length ? key + ":" + y : y);
+					} else {
+						str && (str += " ");
+						str += y;
+					}
 				}
 			}
 		}
@@ -28,12 +34,16 @@ function toVal(mix) {
 }
 
 export function clsx() {
-	var i=0, tmp, x, str='', len=arguments.length;
+	var i = 0,
+		tmp,
+		x,
+		str = "",
+		len = arguments.length;
 	for (; i < len; i++) {
-		if (tmp = arguments[i]) {
-			if (x = toVal(tmp)) {
-				str && (str += ' ');
-				str += x
+		if ((tmp = arguments[i])) {
+			if ((x = toVal(tmp))) {
+				str && (str += " ");
+				str += x;
 			}
 		}
 	}

--- a/test/classnames.js
+++ b/test/classnames.js
@@ -2,92 +2,88 @@
  * Ported from `classnames` for compatibility checks.
  */
 
-import { test } from 'uvu';
-import * as assert from 'uvu/assert';
-import clsx from '../src';
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import clsx from "../src";
 
-test('(compat) keeps object keys with truthy values', () => {
-	const out = clsx({ a:true, b:false, c:0, d:null, e:undefined, f:1 });
-	assert.is(out, 'a f');
+test("(compat) keeps object keys with truthy values", () => {
+	const out = clsx({ a: true, b: false, c: 0, d: null, e: undefined, f: 1 });
+	assert.is(out, "a f");
 });
 
-test('(compat) joins arrays of class names and ignore falsy values', () => {
-	const out = clsx('a', 0, null, undefined, true, 1, 'b');
-	assert.is(out, 'a 1 b');
+test("(compat) joins arrays of class names and ignore falsy values", () => {
+	const out = clsx("a", 0, null, undefined, true, 1, "b");
+	assert.is(out, "a 1 b");
 });
 
-test('(compat) supports heterogenous arguments', () => {
-	assert.is(clsx({ a:true }, 'b', 0), 'a b');
+test("(compat) supports heterogenous arguments", () => {
+	assert.is(clsx({ a: true }, "b", 0), "a b");
 });
 
-test('(compat) should be trimmed', () => {
-	assert.is(clsx('', 'b', {}, ''), 'b');
+test("(compat) should be trimmed", () => {
+	assert.is(clsx("", "b", {}, ""), "b");
 });
 
-test('(compat) returns an empty string for an empty configuration', () => {
-	assert.is(clsx({}), '');
+test("(compat) returns an empty string for an empty configuration", () => {
+	assert.is(clsx({}), "");
 });
 
-test('(compat) supports an array of class names', () => {
-	assert.is(clsx(['a', 'b']), 'a b');
+test("(compat) supports an array of class names", () => {
+	assert.is(clsx(["a", "b"]), "a b");
 });
 
-test('(compat) joins array arguments with string arguments', () => {
-	assert.is(clsx(['a', 'b'], 'c'), 'a b c');
-	assert.is(clsx('c', ['a', 'b']), 'c a b');
+test("(compat) joins array arguments with string arguments", () => {
+	assert.is(clsx(["a", "b"], "c"), "a b c");
+	assert.is(clsx("c", ["a", "b"]), "c a b");
 });
 
-test('(compat) handles multiple array arguments', () => {
-	assert.is(clsx(['a', 'b'], ['c', 'd']), 'a b c d');
+test("(compat) handles multiple array arguments", () => {
+	assert.is(clsx(["a", "b"], ["c", "d"]), "a b c d");
 });
 
-test('(compat) handles arrays that include falsy and true values', () => {
-	assert.is(clsx(['a', 0, null, undefined, false, true, 'b']), 'a b');
+test("(compat) handles arrays that include falsy and true values", () => {
+	assert.is(clsx(["a", 0, null, undefined, false, true, "b"]), "a b");
 });
 
-test('(compat) handles arrays that include arrays', () => {
-	assert.is(clsx(['a', ['b', 'c']]), 'a b c');
+test("(compat) handles arrays that include arrays", () => {
+	assert.is(clsx(["a", ["b", "c"]]), "a b c");
 });
 
-test('(compat) handles arrays that include objects', () => {
-	assert.is(clsx(['a', { b:true, c:false }]), 'a b');
+test("(compat) handles arrays that include objects", () => {
+	assert.is(clsx(["a", { b: true, c: false }]), "a b");
 });
 
-test('(compat) handles deep array recursion', () => {
-	assert.is(clsx(['a', ['b', ['c', { d:true }]]]), 'a b c d');
+test("(compat) handles deep array recursion", () => {
+	assert.is(clsx(["a", ["b", ["c", { d: true }]]]), "a b c d");
 });
 
-test('(compat) handles arrays that are empty', () => {
-	assert.is(clsx('a', []), 'a');
+test("(compat) handles arrays that are empty", () => {
+	assert.is(clsx("a", []), "a");
 });
 
-test('(compat) handles nested arrays that have empty nested arrays', () => {
-	assert.is(clsx('a', [[]]), 'a');
+test("(compat) handles nested arrays that have empty nested arrays", () => {
+	assert.is(clsx("a", [[]]), "a");
 });
 
-test('(compat) handles all types of truthy and falsy property values as expected', () => {
+test("(compat) handles all types of truthy and falsy property values as expected", () => {
 	const out = clsx({
 		// falsy:
 		null: null,
-		emptyString: '',
+		emptyString: "",
 		noNumber: NaN,
 		zero: 0,
 		negativeZero: -0,
 		false: false,
 		undefined: undefined,
 
-		// truthy (literally anything else):
-		nonEmptyString: 'foobar',
-		whitespace: ' ',
+		// truthy
+		nonEmptyString: "foobar",
+		whitespace: " ",
 		function: Object.prototype.toString,
-		emptyObject: {},
-		nonEmptyObject: {a: 1, b: 2},
-		emptyList: [],
-		nonEmptyList: [1, 2, 3],
-		greaterZero: 1
+		greaterZero: 1,
 	});
 
-	assert.is(out, 'nonEmptyString whitespace function emptyObject nonEmptyObject emptyList nonEmptyList greaterZero');
+	assert.is(out, "nonEmptyString whitespace function greaterZero");
 });
 
 test.run();

--- a/test/classnames.js
+++ b/test/classnames.js
@@ -2,74 +2,74 @@
  * Ported from `classnames` for compatibility checks.
  */
 
-import { test } from "uvu";
-import * as assert from "uvu/assert";
-import clsx from "../src";
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import clsx from '../src';
 
-test("(compat) keeps object keys with truthy values", () => {
+test('(compat) keeps object keys with truthy values', () => {
 	const out = clsx({ a: true, b: false, c: 0, d: null, e: undefined, f: 1 });
-	assert.is(out, "a f");
+	assert.is(out, 'a f');
 });
 
-test("(compat) joins arrays of class names and ignore falsy values", () => {
-	const out = clsx("a", 0, null, undefined, true, 1, "b");
-	assert.is(out, "a 1 b");
+test('(compat) joins arrays of class names and ignore falsy values', () => {
+	const out = clsx('a', 0, null, undefined, true, 1, 'b');
+	assert.is(out, 'a 1 b');
 });
 
-test("(compat) supports heterogenous arguments", () => {
-	assert.is(clsx({ a: true }, "b", 0), "a b");
+test('(compat) supports heterogenous arguments', () => {
+	assert.is(clsx({ a: true }, 'b', 0), 'a b');
 });
 
-test("(compat) should be trimmed", () => {
-	assert.is(clsx("", "b", {}, ""), "b");
+test('(compat) should be trimmed', () => {
+	assert.is(clsx('', 'b', {}, ''), 'b');
 });
 
-test("(compat) returns an empty string for an empty configuration", () => {
-	assert.is(clsx({}), "");
+test('(compat) returns an empty string for an empty configuration', () => {
+	assert.is(clsx({}), '');
 });
 
-test("(compat) supports an array of class names", () => {
-	assert.is(clsx(["a", "b"]), "a b");
+test('(compat) supports an array of class names', () => {
+	assert.is(clsx(['a', 'b']), 'a b');
 });
 
-test("(compat) joins array arguments with string arguments", () => {
-	assert.is(clsx(["a", "b"], "c"), "a b c");
-	assert.is(clsx("c", ["a", "b"]), "c a b");
+test('(compat) joins array arguments with string arguments', () => {
+	assert.is(clsx(['a', 'b'], 'c'), 'a b c');
+	assert.is(clsx('c', ['a', 'b']), 'c a b');
 });
 
-test("(compat) handles multiple array arguments", () => {
-	assert.is(clsx(["a", "b"], ["c", "d"]), "a b c d");
+test('(compat) handles multiple array arguments', () => {
+	assert.is(clsx(['a', 'b'], ['c', 'd']), 'a b c d');
 });
 
-test("(compat) handles arrays that include falsy and true values", () => {
-	assert.is(clsx(["a", 0, null, undefined, false, true, "b"]), "a b");
+test('(compat) handles arrays that include falsy and true values', () => {
+	assert.is(clsx(['a', 0, null, undefined, false, true, 'b']), 'a b');
 });
 
-test("(compat) handles arrays that include arrays", () => {
-	assert.is(clsx(["a", ["b", "c"]]), "a b c");
+test('(compat) handles arrays that include arrays', () => {
+	assert.is(clsx(['a', ['b', 'c']]), 'a b c');
 });
 
-test("(compat) handles arrays that include objects", () => {
-	assert.is(clsx(["a", { b: true, c: false }]), "a b");
+test('(compat) handles arrays that include objects', () => {
+	assert.is(clsx(['a', { b: true, c: false }]), 'a b');
 });
 
-test("(compat) handles deep array recursion", () => {
-	assert.is(clsx(["a", ["b", ["c", { d: true }]]]), "a b c d");
+test('(compat) handles deep array recursion', () => {
+	assert.is(clsx(['a', ['b', ['c', { d: true }]]]), 'a b c d');
 });
 
-test("(compat) handles arrays that are empty", () => {
-	assert.is(clsx("a", []), "a");
+test('(compat) handles arrays that are empty', () => {
+	assert.is(clsx('a', []), 'a');
 });
 
-test("(compat) handles nested arrays that have empty nested arrays", () => {
-	assert.is(clsx("a", [[]]), "a");
+test('(compat) handles nested arrays that have empty nested arrays', () => {
+	assert.is(clsx('a', [[]]), 'a');
 });
 
-test("(compat) handles all types of truthy and falsy property values as expected", () => {
+test('(compat) handles all types of truthy and falsy property values as expected', () => {
 	const out = clsx({
 		// falsy:
 		null: null,
-		emptyString: "",
+		emptyString: '',
 		noNumber: NaN,
 		zero: 0,
 		negativeZero: -0,
@@ -77,13 +77,13 @@ test("(compat) handles all types of truthy and falsy property values as expected
 		undefined: undefined,
 
 		// truthy
-		nonEmptyString: "foobar",
-		whitespace: " ",
+		nonEmptyString: 'foobar',
+		whitespace: ' ',
 		function: Object.prototype.toString,
 		greaterZero: 1,
 	});
 
-	assert.is(out, "nonEmptyString whitespace function greaterZero");
+	assert.is(out, 'nonEmptyString whitespace function greaterZero');
 });
 
 test.run();

--- a/test/index.js
+++ b/test/index.js
@@ -1,96 +1,106 @@
 // @ts-check
-import { test } from 'uvu';
-import * as assert from 'uvu/assert';
-import * as mod from '../src';
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import * as mod from "../src";
 
 const fn = mod.default;
 
-test('exports', () => {
-	assert.type(mod.default, 'function', 'exports default function');
-	assert.type(mod.clsx, 'function', 'exports named function');
-	assert.is(mod.default, mod.clsx, 'exports are equal');
-
-	assert.type(mod.default(), 'string', '~> returns string output');
-	assert.type(mod.clsx(), 'string', '~> returns string output');
+test("responsive and pseudo classes", () => {
+	assert.is(
+		fn({ ["lg"]: ["foo", "bar", { ["after"]: ["baz"] }] }),
+		"lg:foo lg:bar lg:after:baz"
+	);
 });
 
-test('strings', () => {
-	assert.is(fn(''), '');
-	assert.is(fn('foo'), 'foo');
-	assert.is(fn(true && 'foo'), 'foo');
-	assert.is(fn(false && 'foo'), '');
+test("exports", () => {
+	assert.type(mod.default, "function", "exports default function");
+	assert.type(mod.clsx, "function", "exports named function");
+	assert.is(mod.default, mod.clsx, "exports are equal");
+
+	assert.type(mod.default(), "string", "~> returns string output");
+	assert.type(mod.clsx(), "string", "~> returns string output");
 });
 
-test('strings (variadic)', () => {
-	assert.is(fn(''), '');
-	assert.is(fn('foo', 'bar'), 'foo bar');
-	assert.is(fn(true && 'foo', false && 'bar', 'baz'), 'foo baz');
-	assert.is(fn(false && 'foo', 'bar', 'baz', ''), 'bar baz');
+test("strings", () => {
+	assert.is(fn(""), "");
+	assert.is(fn("foo"), "foo");
+	assert.is(fn(true && "foo"), "foo");
+	assert.is(fn(false && "foo"), "");
 });
 
-test('numbers', () => {
-	assert.is(fn(1), '1');
-	assert.is(fn(12), '12');
-	assert.is(fn(0.1), '0.1');
-	assert.is(fn(0), '');
-
-	assert.is(fn(Infinity), 'Infinity');
-	assert.is(fn(NaN), '');
+test("strings (variadic)", () => {
+	assert.is(fn(""), "");
+	assert.is(fn("foo", "bar"), "foo bar");
+	assert.is(fn(true && "foo", false && "bar", "baz"), "foo baz");
+	assert.is(fn(false && "foo", "bar", "baz", ""), "bar baz");
 });
 
-test('numbers (variadic)', () => {
-	assert.is(fn(0, 1), '1');
-	assert.is(fn(1, 2), '1 2');
+test("numbers", () => {
+	assert.is(fn(1), "1");
+	assert.is(fn(12), "12");
+	assert.is(fn(0.1), "0.1");
+	assert.is(fn(0), "");
+
+	assert.is(fn(Infinity), "Infinity");
+	assert.is(fn(NaN), "");
 });
 
-test('objects', () => {
-	assert.is(fn({}), '');
-	assert.is(fn({ foo:true }), 'foo');
-	assert.is(fn({ foo:true, bar:false }), 'foo');
-	assert.is(fn({ foo:'hiya', bar:1 }), 'foo bar');
-	assert.is(fn({ foo:1, bar:0, baz:1 }), 'foo baz');
-	assert.is(fn({ '-foo':1, '--bar':1 }), '-foo --bar');
+test("numbers (variadic)", () => {
+	assert.is(fn(0, 1), "1");
+	assert.is(fn(1, 2), "1 2");
 });
 
-test('objects (variadic)', () => {
-	assert.is(fn({}, {}), '');
-	assert.is(fn({ foo:1 }, { bar:2 }), 'foo bar');
-	assert.is(fn({ foo:1 }, null, { baz:1, bat:0 }), 'foo baz');
-	assert.is(fn({ foo:1 }, {}, {}, { bar:'a' }, { baz:null, bat:Infinity }), 'foo bar bat');
+test("objects", () => {
+	assert.is(fn({}), "");
+	assert.is(fn({ foo: true }), "foo");
+	assert.is(fn({ foo: true, bar: false }), "foo");
+	assert.is(fn({ foo: "hiya", bar: 1 }), "foo bar");
+	assert.is(fn({ foo: 1, bar: 0, baz: 1 }), "foo baz");
+	assert.is(fn({ "-foo": 1, "--bar": 1 }), "-foo --bar");
 });
 
-test('arrays', () => {
-	assert.is(fn([]), '');
-	assert.is(fn(['foo']), 'foo');
-	assert.is(fn(['foo', 'bar']), 'foo bar');
-	assert.is(fn(['foo', 0 && 'bar', 1 && 'baz']), 'foo baz');
+test("objects (variadic)", () => {
+	assert.is(fn({}, {}), "");
+	assert.is(fn({ foo: 1 }, { bar: 2 }), "foo bar");
+	assert.is(fn({ foo: 1 }, null, { baz: 1, bat: 0 }), "foo baz");
+	assert.is(
+		fn({ foo: 1 }, {}, {}, { bar: "a" }, { baz: null, bat: Infinity }),
+		"foo bar bat"
+	);
 });
 
-test('arrays (nested)', () => {
-	assert.is(fn([[[]]]), '');
-	assert.is(fn([[['foo']]]), 'foo');
-	assert.is(fn([true, [['foo']]]), 'foo');;
-	assert.is(fn(['foo', ['bar', ['', [['baz']]]]]), 'foo bar baz');
+test("arrays", () => {
+	assert.is(fn([]), "");
+	assert.is(fn(["foo"]), "foo");
+	assert.is(fn(["foo", "bar"]), "foo bar");
+	assert.is(fn(["foo", 0 && "bar", 1 && "baz"]), "foo baz");
 });
 
-test('arrays (variadic)', () => {
-	assert.is(fn([], []), '');
-	assert.is(fn(['foo'], ['bar']), 'foo bar');
-	assert.is(fn(['foo'], null, ['baz', ''], true, '', []), 'foo baz');
+test("arrays (nested)", () => {
+	assert.is(fn([[[]]]), "");
+	assert.is(fn([[["foo"]]]), "foo");
+	assert.is(fn([true, [["foo"]]]), "foo");
+	assert.is(fn(["foo", ["bar", ["", [["baz"]]]]]), "foo bar baz");
 });
 
-test('arrays (no `push` escape)', () => {
-	assert.is(fn({ push:1 }), 'push');
-	assert.is(fn({ pop:true }), 'pop');
-	assert.is(fn({ push:true }), 'push');
-	assert.is(fn('hello', { world:1, push:true }), 'hello world push');
+test("arrays (variadic)", () => {
+	assert.is(fn([], []), "");
+	assert.is(fn(["foo"], ["bar"]), "foo bar");
+	assert.is(fn(["foo"], null, ["baz", ""], true, "", []), "foo baz");
 });
 
-test('functions', () => {
+test("arrays (no `push` escape)", () => {
+	assert.is(fn({ push: 1 }), "push");
+	assert.is(fn({ pop: true }), "pop");
+	assert.is(fn({ push: true }), "push");
+	assert.is(fn("hello", { world: 1, push: true }), "hello world push");
+});
+
+test("functions", () => {
 	const foo = () => {};
-	assert.is(fn(foo, 'hello'), 'hello');
-	assert.is(fn(foo, 'hello', fn), 'hello');
-	assert.is(fn(foo, 'hello', [[fn], 'world']), 'hello world');
+	assert.is(fn(foo, "hello"), "hello");
+	assert.is(fn(foo, "hello", fn), "hello");
+	assert.is(fn(foo, "hello", [[fn], "world"]), "hello world");
 });
 
 test.run();

--- a/test/index.js
+++ b/test/index.js
@@ -1,106 +1,106 @@
 // @ts-check
-import { test } from "uvu";
-import * as assert from "uvu/assert";
-import * as mod from "../src";
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import * as mod from '../src';
 
 const fn = mod.default;
 
-test("responsive and pseudo classes", () => {
+test('responsive and pseudo classes', () => {
 	assert.is(
-		fn({ ["lg"]: ["foo", "bar", { ["after"]: ["baz"] }] }),
-		"lg:foo lg:bar lg:after:baz"
+		fn({ ['lg']: ['foo', 'bar', { ['after']: ['baz'] }] }),
+		'lg:foo lg:bar lg:after:baz'
 	);
 });
 
-test("exports", () => {
-	assert.type(mod.default, "function", "exports default function");
-	assert.type(mod.clsx, "function", "exports named function");
-	assert.is(mod.default, mod.clsx, "exports are equal");
+test('exports', () => {
+	assert.type(mod.default, 'function', 'exports default function');
+	assert.type(mod.clsx, 'function', 'exports named function');
+	assert.is(mod.default, mod.clsx, 'exports are equal');
 
-	assert.type(mod.default(), "string", "~> returns string output");
-	assert.type(mod.clsx(), "string", "~> returns string output");
+	assert.type(mod.default(), 'string', '~> returns string output');
+	assert.type(mod.clsx(), 'string', '~> returns string output');
 });
 
-test("strings", () => {
-	assert.is(fn(""), "");
-	assert.is(fn("foo"), "foo");
-	assert.is(fn(true && "foo"), "foo");
-	assert.is(fn(false && "foo"), "");
+test('strings', () => {
+	assert.is(fn(''), '');
+	assert.is(fn('foo'), 'foo');
+	assert.is(fn(true && 'foo'), 'foo');
+	assert.is(fn(false && 'foo'), '');
 });
 
-test("strings (variadic)", () => {
-	assert.is(fn(""), "");
-	assert.is(fn("foo", "bar"), "foo bar");
-	assert.is(fn(true && "foo", false && "bar", "baz"), "foo baz");
-	assert.is(fn(false && "foo", "bar", "baz", ""), "bar baz");
+test('strings (variadic)', () => {
+	assert.is(fn(''), '');
+	assert.is(fn('foo', 'bar'), 'foo bar');
+	assert.is(fn(true && 'foo', false && 'bar', 'baz'), 'foo baz');
+	assert.is(fn(false && 'foo', 'bar', 'baz', ''), 'bar baz');
 });
 
-test("numbers", () => {
-	assert.is(fn(1), "1");
-	assert.is(fn(12), "12");
-	assert.is(fn(0.1), "0.1");
-	assert.is(fn(0), "");
+test('numbers', () => {
+	assert.is(fn(1), '1');
+	assert.is(fn(12), '12');
+	assert.is(fn(0.1), '0.1');
+	assert.is(fn(0), '');
 
-	assert.is(fn(Infinity), "Infinity");
-	assert.is(fn(NaN), "");
+	assert.is(fn(Infinity), 'Infinity');
+	assert.is(fn(NaN), '');
 });
 
-test("numbers (variadic)", () => {
-	assert.is(fn(0, 1), "1");
-	assert.is(fn(1, 2), "1 2");
+test('numbers (variadic)', () => {
+	assert.is(fn(0, 1), '1');
+	assert.is(fn(1, 2), '1 2');
 });
 
-test("objects", () => {
-	assert.is(fn({}), "");
-	assert.is(fn({ foo: true }), "foo");
-	assert.is(fn({ foo: true, bar: false }), "foo");
-	assert.is(fn({ foo: "hiya", bar: 1 }), "foo bar");
-	assert.is(fn({ foo: 1, bar: 0, baz: 1 }), "foo baz");
-	assert.is(fn({ "-foo": 1, "--bar": 1 }), "-foo --bar");
+test('objects', () => {
+	assert.is(fn({}), '');
+	assert.is(fn({ foo: true }), 'foo');
+	assert.is(fn({ foo: true, bar: false }), 'foo');
+	assert.is(fn({ foo: 'hiya', bar: 1 }), 'foo bar');
+	assert.is(fn({ foo: 1, bar: 0, baz: 1 }), 'foo baz');
+	assert.is(fn({ '-foo': 1, '--bar': 1 }), '-foo --bar');
 });
 
-test("objects (variadic)", () => {
-	assert.is(fn({}, {}), "");
-	assert.is(fn({ foo: 1 }, { bar: 2 }), "foo bar");
-	assert.is(fn({ foo: 1 }, null, { baz: 1, bat: 0 }), "foo baz");
+test('objects (variadic)', () => {
+	assert.is(fn({}, {}), '');
+	assert.is(fn({ foo: 1 }, { bar: 2 }), 'foo bar');
+	assert.is(fn({ foo: 1 }, null, { baz: 1, bat: 0 }), 'foo baz');
 	assert.is(
-		fn({ foo: 1 }, {}, {}, { bar: "a" }, { baz: null, bat: Infinity }),
-		"foo bar bat"
+		fn({ foo: 1 }, {}, {}, { bar: 'a' }, { baz: null, bat: Infinity }),
+		'foo bar bat'
 	);
 });
 
-test("arrays", () => {
-	assert.is(fn([]), "");
-	assert.is(fn(["foo"]), "foo");
-	assert.is(fn(["foo", "bar"]), "foo bar");
-	assert.is(fn(["foo", 0 && "bar", 1 && "baz"]), "foo baz");
+test('arrays', () => {
+	assert.is(fn([]), '');
+	assert.is(fn(['foo']), 'foo');
+	assert.is(fn(['foo', 'bar']), 'foo bar');
+	assert.is(fn(['foo', 0 && 'bar', 1 && 'baz']), 'foo baz');
 });
 
-test("arrays (nested)", () => {
-	assert.is(fn([[[]]]), "");
-	assert.is(fn([[["foo"]]]), "foo");
-	assert.is(fn([true, [["foo"]]]), "foo");
-	assert.is(fn(["foo", ["bar", ["", [["baz"]]]]]), "foo bar baz");
+test('arrays (nested)', () => {
+	assert.is(fn([[[]]]), '');
+	assert.is(fn([[['foo']]]), 'foo');
+	assert.is(fn([true, [['foo']]]), 'foo');
+	assert.is(fn(['foo', ['bar', ['', [['baz']]]]]), 'foo bar baz');
 });
 
-test("arrays (variadic)", () => {
-	assert.is(fn([], []), "");
-	assert.is(fn(["foo"], ["bar"]), "foo bar");
-	assert.is(fn(["foo"], null, ["baz", ""], true, "", []), "foo baz");
+test('arrays (variadic)', () => {
+	assert.is(fn([], []), '');
+	assert.is(fn(['foo'], ['bar']), 'foo bar');
+	assert.is(fn(['foo'], null, ['baz', ''], true, '', []), 'foo baz');
 });
 
-test("arrays (no `push` escape)", () => {
-	assert.is(fn({ push: 1 }), "push");
-	assert.is(fn({ pop: true }), "pop");
-	assert.is(fn({ push: true }), "push");
-	assert.is(fn("hello", { world: 1, push: true }), "hello world push");
+test('arrays (no `push` escape)', () => {
+	assert.is(fn({ push: 1 }), 'push');
+	assert.is(fn({ pop: true }), 'pop');
+	assert.is(fn({ push: true }), 'push');
+	assert.is(fn('hello', { world: 1, push: true }), 'hello world push');
 });
 
-test("functions", () => {
+test('functions', () => {
 	const foo = () => {};
-	assert.is(fn(foo, "hello"), "hello");
-	assert.is(fn(foo, "hello", fn), "hello");
-	assert.is(fn(foo, "hello", [[fn], "world"]), "hello world");
+	assert.is(fn(foo, 'hello'), 'hello');
+	assert.is(fn(foo, 'hello', fn), 'hello');
+	assert.is(fn(foo, 'hello', [[fn], 'world']), 'hello world');
 });
 
 test.run();


### PR DESCRIPTION
Instead of writing:
`hover:foo hover:bar hover:baz hover:after:foo hover:after:baz`

This proposes:
`clsx({ hover: ["foo", "bar", "baz", { after: ["foo", "baz"] }] });`

Please excuse the reformatting of code :)