### PR TITLE
Lite Version: Improve Typescript Definition and Support for "moduleResolution": "Node"

### DIFF
--- a/clsx-lite.d.mts
+++ b/clsx-lite.d.mts
@@ -1,0 +1,4 @@
+export type ClassValue = string | number | null | boolean | undefined;
+
+export function clsx(...inputs: ClassValue[]): string;
+export default clsx;

--- a/clsx-lite.d.ts
+++ b/clsx-lite.d.ts
@@ -1,0 +1,8 @@
+declare namespace clsx {
+	type ClassValue = string | number | null | boolean | undefined;
+	function clsx(...inputs: ClassValue[]): string;
+}
+
+declare function clsx(...inputs: clsx.ClassValue[]): string;
+
+export = clsx;

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     },
     "./lite": {
       "import": {
-        "types": "./clsx.d.mts",
+        "types": "./clsx-lite.d.mts",
         "default": "./dist/lite.mjs"
       },
       "default": {
-        "types": "./clsx.d.ts",
+        "types": "./clsx-lite.d.ts",
         "default": "./dist/lite.js"
       }
     }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,14 @@
   "unpkg": "dist/clsx.min.js",
   "main": "dist/clsx.js",
   "types": "clsx.d.ts",
+  "typesVersions": {
+    "*": {
+      "lite": [
+        "./clsx-lite.d.mts",
+        "./clsx-lite.d.ts"
+      ]
+    }
+  },
   "license": "MIT",
   "exports": {
     ".": {


### PR DESCRIPTION
Hey there,
thanks for this important module!

- I added two more Typescript Definitions for Lite Version (only removed ClassDictionary  and ClassArray)
- I added typesVersions inside package.json to support older moduleResolution at tsconfig.json

see:
https://github.com/lukeed/clsx/issues/92
https://github.com/lukeed/clsx/issues/90
https://github.com/lukeed/clsx/issues/89

thanks!

Grettings
crazyx13th