### PR TITLE
fix: allow `bigint` in typings

### DIFF
--- a/clsx.d.mts
+++ b/clsx.d.mts
@@ -1,4 +1,4 @@
-export type ClassValue = ClassArray | ClassDictionary | string | number | null | boolean | undefined;
+export type ClassValue = ClassArray | ClassDictionary | string | number | bigint | null | boolean | undefined;
 export type ClassDictionary = Record<string, any>;
 export type ClassArray = ClassValue[];
 

--- a/clsx.d.ts
+++ b/clsx.d.ts
@@ -1,5 +1,5 @@
 declare namespace clsx {
-	type ClassValue = ClassArray | ClassDictionary | string | number | null | boolean | undefined;
+	type ClassValue = ClassArray | ClassDictionary | string | number | bigint | null | boolean | undefined;
 	type ClassDictionary = Record<string, any>;
 	type ClassArray = ClassValue[];
 	function clsx(...inputs: ClassValue[]): string;


### PR DESCRIPTION
`ReactNode` from `@types/react` now includes `bigint` (and its `0n` zero which is falsy) and that is incompatible with `clsx` in these scenarios:

```tsx
declare const x: ReactNode

const className = clsx(x && 'some-class')
// Argument of type 'false | "" | 0 | 0n | "some-class" | null | undefined' is not assignable to parameter of type 'ClassValue'.
//  Type '0n' is not assignable to type 'ClassValue'.
```