### PR TITLE
fix: improve type test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,25 @@
-const is = (x, t) => Object.prototype.toString.call(x) === `[object ${t}]`;
+const is = (val, type) => Object.prototype.toString.call(val) === `[object ${type}]`;
 
 function toVal(mix) {
 	var k, y, str='';
 
 	if (is(mix, 'String') || is(mix, 'Number')) {
 		str += mix;
-	} else if (is(mix, 'Object')) {
-		if (Array.isArray(mix)) {
+	} else if (is(mix, 'Array')) {
 			var len=mix.length;
 			for (k=0; k < len; k++) {
-				if (mix[k]) {
+				if (mix[k] && mix[k].valueOf()) {
 					if (y = toVal(mix[k])) {
 						str && (str += ' ');
 						str += y;
 					}
 				}
 			}
-		} else {
-			for (y in mix) {
-				if (mix[y]) {
-					str && (str += ' ');
-					str += y;
-				}
+	} else if (is(mix, 'Object')) {
+		for (y in mix) {
+			if (mix[y] && mix[y].valueOf()) {
+				str && (str += ' ');
+				str += y;
 			}
 		}
 	}
@@ -32,7 +30,7 @@ function toVal(mix) {
 export function clsx() {
 	var i=0, tmp, x, str='', len=arguments.length;
 	for (; i < len; i++) {
-		if (tmp = arguments[i]) {
+		if ((tmp = arguments[i]) && tmp.valueOf()) {
 			if (x = toVal(tmp)) {
 				str && (str += ' ');
 				str += x

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
+const is = (x, t) => Object.prototype.toString.call(x) === `[object ${t}]`;
+
 function toVal(mix) {
 	var k, y, str='';
 
-	if (typeof mix === 'string' || typeof mix === 'number') {
+	if (is(mix, 'String') || is(mix, 'Number')) {
 		str += mix;
-	} else if (typeof mix === 'object') {
+	} else if (is(mix, 'Object')) {
 		if (Array.isArray(mix)) {
 			var len=mix.length;
 			for (k=0; k < len; k++) {

--- a/src/lite.js
+++ b/src/lite.js
@@ -2,7 +2,7 @@ export function clsx() {
 	var i=0, tmp, str='', len=arguments.length;
 	for (; i < len; i++) {
 		if (tmp = arguments[i]) {
-			if (typeof tmp === 'string') {
+			if (Object.prototype.toString.call(tmp) === '[object String]') {
 				str += (str && ' ') + tmp;
 			}
 		}

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,20 @@ test('strings (variadic)', () => {
 	assert.is(fn(false && 'foo', 'bar', 'baz', ''), 'bar baz');
 });
 
+test('string instances', () => {
+	assert.is(fn(new String('')), '');
+	assert.is(fn(new String('foo')), 'foo');
+	assert.is(fn(true && new String('foo')), 'foo');
+	assert.is(fn(false && new String('foo')), '');
+});
+
+test('string instances (variadic)', () => {
+	assert.is(fn(new String('')), '');
+	assert.is(fn(new String('foo'), new String('bar')), 'foo bar');
+	assert.is(fn(true && new String('foo'), false && new String('bar'), new String('baz')), 'foo baz');
+	assert.is(fn(false && new String('foo'), new String('bar'), new String('baz'), ''), 'bar baz');
+});
+
 test('numbers', () => {
 	assert.is(fn(1), '1');
 	assert.is(fn(12), '12');
@@ -41,6 +55,21 @@ test('numbers', () => {
 test('numbers (variadic)', () => {
 	assert.is(fn(0, 1), '1');
 	assert.is(fn(1, 2), '1 2');
+});
+
+test('number instances', () => {
+	assert.is(fn(new Number(1)), '1');
+	assert.is(fn(new Number(12)), '12');
+	assert.is(fn(new Number(0.1)), '0.1');
+	assert.is(fn(new Number(0)), '');
+
+	assert.is(fn(new Number(Infinity)), 'Infinity');
+	assert.is(fn(new Number(NaN)), '');
+});
+
+test('number instances (variadic)', () => {
+	assert.is(fn(new Number(0), new Number(1)), '1');
+	assert.is(fn(new Number(1), new Number(2)), '1 2');
 });
 
 test('objects', () => {

--- a/test/lite.js
+++ b/test/lite.js
@@ -28,6 +28,20 @@ test('strings (variadic)', () => {
 	assert.is(fn(false && 'foo', 'bar', 'baz', ''), 'bar baz');
 });
 
+test('string instances', () => {
+	assert.is(fn(new String('')), '');
+	assert.is(fn(new String('foo')), 'foo');
+	assert.is(fn(true && new String('foo')), 'foo');
+	assert.is(fn(false && new String('foo')), '');
+});
+
+test('string instances (variadic)', () => {
+	assert.is(fn(new String('')), '');
+	assert.is(fn(new String('foo'), new String('bar')), 'foo bar');
+	assert.is(fn(true && new String('foo'), false && new String('bar'), new String('baz')), 'foo baz');
+	assert.is(fn(false && new String('foo'), new String('bar'), new String('baz'), ''), 'bar baz');
+});
+
 test('emptys', () => {
 	assert.is(fn(''), '');
 	assert.is(fn(undefined), '');


### PR DESCRIPTION
I was making some BEM CSS transformers for Vite and stumbled on a bug:

The module.css will be transformed to something resembling this:

```javascript
const ClassIdentifierMap = {}
ClassIdentifierMap['block'] = new String('block')
ClassIdentifierMap['block']['element'] = new String('block__element')
ClassIdentifierMap['block']['element']['$hasError'] = new String('block__element--has-error')

export default ClassIdentifierMap
```

Using it as:

```javascript
import classes from './Whatever.module.css'

clsx(classes.block.element, hasError && classes.block.element.$hasError)
```

It will always fail because it will check and fail to see that all those are strings, treat it as an object, and try to check the keys.

This PR fixes it on both clsx and clsx/lite.