### PR TITLE
docs: Tweak Tailwind CSS Intellisense regex to handle inner brackets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ Here some additional (optional) steps to enable classes autocompletion using `cl
   ```json
    {
     "tailwindCSS.experimental.classRegex": [
-      ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+      ["clsx\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
     ]
    }
   ```


### PR DESCRIPTION
The current Tailwind CSS Intellisense regex doesn't handle inner brackets, for example if I have a value of

```ts
clsx([`bg-background focus:shadow-[0_0_15px_0_rgba(0,0,0,0.1)] text-foreground`]);
```

Then the current regex will stop matching after the `rgba(0,0,0,0.1)` because of the end bracket. Demo https://regex101.com/r/B35VfZ/1

This updated regex handles inner brackets. Demo https://regex101.com/r/WocUfB/1