### PR TITLE
feat: declare package as side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.1",
   "repository": "lukeed/clsx",
   "description": "A tiny (239B) utility for constructing className strings conditionally.",
+  "sideEffects": false,
   "module": "dist/clsx.mjs",
   "unpkg": "dist/clsx.min.js",
   "main": "dist/clsx.js",


### PR DESCRIPTION
Hey! Small update to enable complete tree-shaking of clsx and prevent bare imports `import "clsx";` from ending in bundles

Reference: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free (rollup also supports it)